### PR TITLE
Fixing issues when defining special headers

### DIFF
--- a/spec/carbon_smtp_adapter_spec.cr
+++ b/spec/carbon_smtp_adapter_spec.cr
@@ -24,12 +24,15 @@ class TestEmail < BaseEmail
   subject "Test Subject"
   templates text, html
   header "X-Crystal-Version", "0.27"
+  header "Reply-To", "support@myapp.com"
+  header "Message-ID", "<abc123@myapp.com>"
+  header "Return-Path", "support@myapp.com"
+  header "Sender", "support@myapp.com"
 end
 
 describe CarbonSmtpAdapter do
   it "works" do
     email = TestEmail.new
-    p email.headers
     Carbon::SmtpAdapter.new.deliver_now(email)
 
     email_store.count.should eq(1)

--- a/src/carbon/adapters/smtp_adapter.cr
+++ b/src/carbon/adapters/smtp_adapter.cr
@@ -30,8 +30,15 @@ class Carbon::SmtpAdapter < Carbon::Adapter
       end
 
       email.headers.each do |key, value|
-        if key == "Reply-To"
+        case key.downcase
+        when "reply-to"
           reply_to(value)
+        when "message-id"
+          message_id(value)
+        when "return-path"
+          return_path(value)
+        when "sender"
+          sender(value)
         else
           custom_header(key, value)
         end


### PR DESCRIPTION
If you define a custom `Message-ID`, `Return-Path`, or `Sender` header in Carbon, there's a runtime exception that tells you to not do that because there's custom methods that have to be called

```
Message-ID header must be set by using #message_id method (EMail::Error::MessageError)
```

This PR fixes it.