### PR TITLE
Carbon & Crystal Email version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A simple SMTP-Adapter for [carbon](https://github.com/luckyframework/carbon).
 ## Versioning
 
 The current plan is to track carbon's major and minor numbers, so that
-carbon\_smtp\_adapter `0.1.x` is compatible with carbon `0.1.x` and so on.
+carbon\_smtp\_adapter `0.1.x` is compatible with carbon `0.3.x` and so on.
 
 ## Installation
 
@@ -45,7 +45,7 @@ end
 
 ## Contributing
 
-1. Fork it (<https://github.com/oneiros/carbon_smtp_adapter/fork>)
+1. Fork it ([https://github.com/oneiros/carbon_smtp_adapter/fork](https://github.com/oneiros/carbon_smtp_adapter/fork))
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)

--- a/shard.yml
+++ b/shard.yml
@@ -14,7 +14,7 @@ dependencies:
     version: ~> 0.3.0
   email:
     github: arcage/crystal-email
-    version: ~> 0.6.1
+    version: ~> 0.7.0
 development_dependencies:
   devmail:
     github: tijn/devmail

--- a/shard.yml
+++ b/shard.yml
@@ -11,7 +11,7 @@ license: MIT
 dependencies:
   carbon:
     github: luckyframework/carbon
-    version: ~> 0.2.0
+    version: ~> 0.3.0
   email:
     github: arcage/crystal-email
     version: ~> 0.6.1

--- a/spec/carbon_smtp_adapter_spec.cr
+++ b/spec/carbon_smtp_adapter_spec.cr
@@ -9,6 +9,7 @@ smtp_server.run
 Carbon::SmtpAdapter.configure do |settings|
   settings.port = SMTP_PORT
   settings.use_tls = false
+  settings.helo_domain = "localhost"
 end
 
 abstract class BaseEmail < Carbon::Email

--- a/src/carbon/adapters/smtp_adapter.cr
+++ b/src/carbon/adapters/smtp_adapter.cr
@@ -2,7 +2,7 @@ class Carbon::SmtpAdapter < Carbon::Adapter
   Habitat.create do
     setting host : String = "localhost"
     setting port : Int32 = 25
-    setting helo_domain : String? = nil
+    setting helo_domain : String
     setting use_tls : Bool = true
     setting username : String? = nil
     setting password : String? = nil
@@ -12,7 +12,7 @@ class Carbon::SmtpAdapter < Carbon::Adapter
     auth = get_auth_tuple
 
     use_tls = settings.use_tls ? ::EMail::Client::TLSMode::STARTTLS : ::EMail::Client::TLSMode::NONE
-    ::EMail.send(settings.host, settings.port, auth: auth, use_tls: use_tls) do
+    ::EMail.send(settings.host, settings.port, auth: auth, use_tls: use_tls, helo_domain: get_helo_domain) do
       subject email.subject
 
       from(email.from.address, email.from.name)
@@ -63,5 +63,13 @@ class Carbon::SmtpAdapter < Carbon::Adapter
     if username && password
       {username, password}
     end
+  end
+
+  private def get_helo_domain : String
+    if settings.helo_domain.nil?
+      raise "'helo_domain' setting is not provided"
+    end
+
+    return settings.helo_domain
   end
 end


### PR DESCRIPTION
- Bump carbon version to 3.0
- Bump crystal email version to 0.7.0
- Update carbon version to '0.3.x' in README

BREAKING CHANGE:

`helo_domain` is now required when configuring the smtp adapter - https://github.com/arcage/crystal-email/releases/tag/v0.7.0


This PR resolves issue #7 