### PR TITLE
Update to the latest Email shard. 

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -14,7 +14,7 @@ dependencies:
     version: ">= 0.3.0"
   email:
     github: arcage/crystal-email
-    version: ~> 0.6.1
+    version: ">= 0.7.0, < 0.8"
 development_dependencies:
   devmail:
     github: tijn/devmail

--- a/src/carbon/adapters/smtp_adapter.cr
+++ b/src/carbon/adapters/smtp_adapter.cr
@@ -11,8 +11,9 @@ class Carbon::SmtpAdapter < Carbon::Adapter
   def deliver_now(email : Carbon::Email)
     auth = get_auth_tuple
 
+    helo_domain = settings.helo_domain || settings.host
     use_tls = settings.use_tls ? ::EMail::Client::TLSMode::STARTTLS : ::EMail::Client::TLSMode::NONE
-    ::EMail.send(settings.host, settings.port, auth: auth, use_tls: use_tls) do
+    ::EMail.send(settings.host, settings.port, helo_domain: helo_domain, auth: auth, use_tls: use_tls) do
       subject email.subject
 
       from(email.from.address, email.from.name)


### PR DESCRIPTION
Fixes #7
Closes #9 

According to [This post](https://serverfault.com/questions/305925/what-exactly-should-helo-say) the `HELO` value should be where you're sending the email from. 

Looking at how it's handled in Ruby, the `Net::SMTP` gem used to be a part of the Ruby core, and originally used `localhost` as the default value https://docs.ruby-lang.org/en/2.4.0/Net/SMTP.html At some point, this gem was abstracted to a separate library, and since then, they made the decision to default this value to `nil`. 

https://github.com/ruby/net-smtp/blob/c41e2990d68338e60a4234c1d56f223aa6d164d2/lib/net/smtp.rb#L517

Since the CrystalEmail shard requires a string value for `helo_domain`, I think we can just keep our default as `nil`, and then just pass in the `host` value.

https://github.com/arcage/crystal-email/blob/2f6ee366e6fd2ea24ed1df484eaab39e19ffdc0b/src/email/client/config.cr#L150

My guess is most people will use SMTP to send to a mail relay service like SendGrid, or Gmail, and those will handle their own helo_domain internally.