### PR TITLE
Release v0.4.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: carbon_smtp_adapter
-version: 0.2.0
+version: 0.4.0
 
 authors:
   - David Roetzel <david@roetzel.de>
@@ -11,7 +11,7 @@ license: MIT
 dependencies:
   carbon:
     github: luckyframework/carbon
-    version: ">= 0.3.0"
+    version: ">= 0.4.0"
   email:
     github: arcage/crystal-email
     version: ">= 0.7.0, < 0.8"


### PR DESCRIPTION
This is a new minor release because it includes a fairly big update to the Email shard internally. I'm also skipping v0.3.0 to keep in line with Carbon itself.