### PR TITLE
Release v0.5.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: carbon_smtp_adapter
-version: 0.4.0
+version: 0.5.0
 
 authors:
   - David Roetzel <david@roetzel.de>


### PR DESCRIPTION
This release is pinned to Carbon v0.5.0 which includes support for attachments.